### PR TITLE
Standardize Packet.from_binary/1 return

### DIFF
--- a/lib/pummpcomm/session/pump_executor.ex
+++ b/lib/pummpcomm/session/pump_executor.ex
@@ -110,7 +110,8 @@ defmodule Pummpcomm.Session.PumpExecutor do
       end
     else
       {:error, reason} ->
-        message = "do_prelude errored with reason #{reason}"
+        # use `inspect` to handle complex `reason`s like tuples, maps, and structs
+        message = "do_prelude errored with reason #{inspect(reason)}"
         # Logger.error message, context: context
         Context.add_error(context, message)
     end


### PR DESCRIPTION
The convention for Either returns in Erlang is `{:ok, value} | {:error, reason}`, but `Pummpcomm.Session.Packet.from_binary/1` returns uses `:invalid_packet` instead of `:error` for the tag.  This both goes against convention, but also leads to a dialyzer warnings because
`Pummpcomm.Session.PumpExecutor.do_prelude/1`'s `with`'s `else` clause only handles `{:error, reason}` tuples.  To fix the convention mismatch the dialyzer warning, change the error format to `{:error, {:invalid_packet, invalid_packet_reason}}`.  Use a tagged tuple for the reason is allowed when there's a subheirarchy of errors as is the case for `:invalid_packet`.

Another convention is to use atoms for the `reason` and not Strings, as it allows for easier matching.  String errors should only be used when the error is going directly to the user, so it would make sense for String errors in the Phoenix or command line UI, but not in the library called from Phoenix or the command line interface.

# Changelog
## Bug Fixes
* Fix dialyzer never match warnings about `{:invalid_packet, _}` 
  ```
  lib/pummpcomm/session/pump_executor.ex:112: The pattern {'error', _reason@1} can never match the type {'invalid_packet',<<_:64,_:_*8>>}
  lib/pummpcomm/session/pump_executor.ex:150: The pattern {'error', _reason@1} can never match the type {'invalid_packet',<<_:64,_:_*8>>}
  ```
  * `Pummpcomm.Session.PumpExecutor.do_prelude/1` will `inspect` the `:error` `reason` instead of `to_string` the `reason` to prevent errors when the `reason` is not a `String.t`.

## Incompatible Changes
* `Pummpcomm.Session.Packet.from_binary/1` return changes from `{:ok, Pummpcomm.Session.Packet.t} | {:invalid_packet, String.t}` to `{:ok, Pummpcomm.Session.Packet.t} | {:error, {:invalid, :crc_mismatch | :packet_too_short}}`